### PR TITLE
Bugfix: Ensure coordinator belongs to current tree at onDisappear

### DIFF
--- a/Sources/Stinsen/NavigationCoordinatable/NavigationCoordinatableView.swift
+++ b/Sources/Stinsen/NavigationCoordinatable/NavigationCoordinatableView.swift
@@ -48,7 +48,12 @@ struct NavigationCoordinatableView<T: NavigationCoordinatable>: View {
             .onDisappear(perform: {
                 // Find the appearing coordinator
                 guard let appearingCoordinator = self.root.coordinator.allChildCoordinators.first(where: {
-                    return $0.appearingMetadata?.appearing != nil
+                    guard ($0.appearingMetadata?.appearing) != nil else { return false }
+
+                    // only return coordinators in the current tree
+                    return ([$0] + $0.allChildCoordinators).contains(where: { (it) -> Bool in
+                        it.id == coordinator.id
+                    })
                 }) else {
                     return
                 }


### PR DESCRIPTION
My team at Mirage discovered and fixed an issue, please review and merge!

When a coordinator has two childcoordinators, in the case of a split view in our case, the onDisappear will pick out the wrong appearingMetadata and the wrong coordinator will be picked.

To test:
Create a view with two coordinators
Push a coordinator
Press back to dismiss
Push another coordinator

Expected result:
Another coordinator should be pushed

Actual result:
Nothing is pushed 