### PR TITLE
Fix build failure on MacOS due to missing function

### DIFF
--- a/Sources/Stinsen/NavigationCoordinatable/PresentationHelper.swift
+++ b/Sources/Stinsen/NavigationCoordinatable/PresentationHelper.swift
@@ -25,25 +25,22 @@ final class PresentationHelper<T: NavigationCoordinatable>: ObservableObject {
                         let view = AnyView(NavigationCoordinatableView(id: nextId, coordinator: coordinator))
 
                         #if os(macOS)
-                        self.presented = .modal(
-                            AnyView(
+                        self.presented = Presented(
+                            view: AnyView(
                                 NavigationView(
                                     content: {
                                         view
                                     }
                                 )
-                            )
+                            ),
+                            type: .modal
                         )
                         #else
                         self.presented = Presented(
                             view: AnyView(
                                 NavigationView(
                                     content: {
-                                        #if os(macOS)
-                                        view
-                                        #else
                                         view.navigationBarHidden(true)
-                                        #endif
                                     }
                                 )
                                 .navigationViewStyle(StackNavigationViewStyle())


### PR DESCRIPTION
I only just started looking at this library but hit a build error when adding it to a multiplatform app. I'm assuming this was due to an old method that has been removed during the 2.0 refactoring.