### PR TITLE
Add an 'unwrapped' navigation coordinator

### DIFF
--- a/Sources/Stinsen/NavigationViewCoordinator/UnwrappedNavigationViewCoordinator.swift
+++ b/Sources/Stinsen/NavigationViewCoordinator/UnwrappedNavigationViewCoordinator.swift
@@ -1,0 +1,19 @@
+import Foundation
+import SwiftUI
+
+/// The UnwrappedNavigationViewCoordinator represents a simplified coordinator
+///
+/// This class can be seen a a convenience class for creating a Coordinator view without wrapping
+/// it in a NavigationView
+public class UnwrappedNavigationViewCoordinator<T: Coordinatable>: ViewWrapperCoordinator<T, AnyView> {
+    public init(_ childCoordinator: T) {
+        super.init(childCoordinator) { view in
+            AnyView(view)
+        }
+    }
+
+    @available(*, unavailable)
+    public override init(_ childCoordinator: T, _ view: @escaping (AnyView) -> AnyView) {
+        fatalError("view cannot be customized")
+    }
+}

--- a/StinsenApp/Shared/Coordinators/Authenticated/AuthenticatedCoordinator+Factory.swift
+++ b/StinsenApp/Shared/Coordinators/Authenticated/AuthenticatedCoordinator+Factory.swift
@@ -12,8 +12,8 @@ extension AuthenticatedCoordinator {
         Text("Testbed")
     }
 
-    func makeHome() -> NavigationViewCoordinator<HomeCoordinator> {
-        return NavigationViewCoordinator(HomeCoordinator(todosStore: todosStore))
+    func makeHome() -> UnwrappedNavigationViewCoordinator<HomeCoordinator> {
+        return UnwrappedNavigationViewCoordinator(HomeCoordinator(todosStore: todosStore))
     }
     
     @ViewBuilder func makeHomeTab(isActive: Bool) -> some View {


### PR DESCRIPTION
Adds the `UnwrappedNavigationViewCoordinator` as a 'convenience' class. This class is a simplified version of the `NavigationViewCoordinator`, with the only difference that it doesn't wrap the view in a NavigationView.

Using this class over the `NavigationViewCoordinator` results in a 'single' view on macOS, instead of macOS choosing to make it split screen (due to the `NavigationViewCoordinator`'s NavigationView).

The same effect can be achieved without this class, but it keeps the factory methods clean and consistent with each other (see the `AuthenticationCoordinator+Factory` file for an example).