### PR TITLE
Utils for NavigationStack

### DIFF
--- a/Sources/Stinsen/NavigationCoordinatable/NavigationStack.swift
+++ b/Sources/Stinsen/NavigationCoordinatable/NavigationStack.swift
@@ -39,12 +39,21 @@ public class NavigationStack<T: NavigationCoordinatable> {
 }
 
 /// Convenience checks against the navigation stack's contents
-extension NavigationStack {
-    public var currentRouteHash: Int {
+public extension NavigationStack {
+    /**
+        The Hash of the route at the top of the stack
+        - Returns: the hash of the route at the top of the stack or -1
+     */
+    var currentRoute: Int {
         return value.last?.keyPath ?? -1
     }
-    
-    private func isInStack(_ keyPathHash: Int) -> Bool {
+
+    /**
+    Checks if a particular KeyPath is in a stack
+     - Parameter keyPathHash:The hash of the keyPath
+     - Returns: Boolean indiacting whether the route is in the stack
+     */
+    func isInStack(_ keyPathHash: Int) -> Bool {
         return value.contains { $0.keyPath == keyPathHash }
     }
 }

--- a/Sources/Stinsen/NavigationCoordinatable/NavigationStack.swift
+++ b/Sources/Stinsen/NavigationCoordinatable/NavigationStack.swift
@@ -38,6 +38,17 @@ public class NavigationStack<T: NavigationCoordinatable> {
     }
 }
 
+/// Convenience checks against the navigation stack's contents
+extension NavigationStack {
+    public var currentRouteHash: Int {
+        return value.last?.keyPath ?? -1
+    }
+    
+    private func isInStack(_ keyPathHash: Int) -> Bool {
+        return value.contains { $0.keyPath == keyPathHash }
+    }
+}
+
 struct NavigationStackItem {
     let presentationType: PresentationType
     let presentable: ViewPresentable


### PR DESCRIPTION
**Proposal**
We're using Stinsen fairly extensively in our projects at Octopus Energy (and really enjoying it!). We've found a few cases where reasoning about which screen you're on is important. Currently everything in `NavigationStack` is internal and therefore inaccessible to `NavigationCoordinatable` implementations.  

This PR adds an extension with some some minor additions to `NavigationStack` for the following:
- `currentRoute` exposes the last object in the navigation stack to `NavigationCoordinatable` implementations
- `isInStack(_: Int) -> Bool` interrogates the stack for a particular root