### PR TITLE
Feature/fix crash

### DIFF
--- a/Examples/MVVM/Shared/Login/ViewModels/MockLoginViewModel.swift
+++ b/Examples/MVVM/Shared/Login/ViewModels/MockLoginViewModel.swift
@@ -14,7 +14,7 @@ final class MockLoginViewModel: LoginViewModel {
     var error: Error?
     
     func login() async throws {
-        await Task.sleep(2_000_000_000)
+        await Task.Task.sleep(nanoseconds: 2_000_000_000)
         
         if let error = error {
             throw error

--- a/Sources/Stinsen/ViewWrapperCoordinator/ViewWrapperCoordinator.swift
+++ b/Sources/Stinsen/ViewWrapperCoordinator/ViewWrapperCoordinator.swift
@@ -4,7 +4,12 @@ import SwiftUI
 /// The NavigationViewCoordinator is used to represent a coordinator with a NavigationView
 open class ViewWrapperCoordinator<T: Coordinatable, V: View>: Coordinatable {
     public func dismissChild<T: Coordinatable>(coordinator: T, action: (() -> Void)?) {
-        self.parent?.dismissChild(coordinator: self, action: action)
+        guard let parent = self.parent else {
+            assertionFailure("Can not dismiss a coordinator since no coordinator is presented.")
+            return
+        }
+        
+        parent.dismissChild(coordinator: self, action: action)
     }
 
     public weak var parent: ChildDismissable?

--- a/Sources/Stinsen/ViewWrapperCoordinator/ViewWrapperCoordinator.swift
+++ b/Sources/Stinsen/ViewWrapperCoordinator/ViewWrapperCoordinator.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// The NavigationViewCoordinator is used to represent a coordinator with a NavigationView
 open class ViewWrapperCoordinator<T: Coordinatable, V: View>: Coordinatable {
     public func dismissChild<T: Coordinatable>(coordinator: T, action: (() -> Void)?) {
-        self.parent!.dismissChild(coordinator: self, action: action)
+        self.parent?.dismissChild(coordinator: self, action: action)
     }
 
     public weak var parent: ChildDismissable?


### PR DESCRIPTION
- prevent crash when parent is nil on ViewWrapperCoordinator
- update deprecated code on Examples/MVVM/Shared/Login/ViewModels/MockLoginViewModel.swift
