### PR TITLE
Fixes compile-time error on Xcode 14 (example app)

### DIFF
--- a/Examples/App/Shared/Coordinators/Main/MainCoordinator.swift
+++ b/Examples/App/Shared/Coordinators/Main/MainCoordinator.swift
@@ -4,7 +4,7 @@ import SwiftUI
 import Stinsen
 
 final class MainCoordinator: NavigationCoordinatable {
-    var stack: NavigationStack<MainCoordinator>
+    var stack: Stinsen.NavigationStack<MainCoordinator>
 
     @Root var unauthenticated = makeUnauthenticated
     @Root var authenticated = makeAuthenticated


### PR DESCRIPTION
Need to add the `Stinsen` namestace due to naming clash with new [`NavigationStack` on iOS 16](https://developer.apple.com/documentation/swiftui/navigationstack/)

![Screenshot 2022-06-18 at 07 12 33](https://user-images.githubusercontent.com/868454/174402202-0ec93f27-e125-448b-81c8-55039d46ac12.png)

