### PR TITLE
Add onTapped to TabItems

### DIFF
--- a/Examples/App/Shared/Coordinators/Authenticated/AuthenticatedCoordinator+Factory.swift
+++ b/Examples/App/Shared/Coordinators/Authenticated/AuthenticatedCoordinator+Factory.swift
@@ -13,7 +13,9 @@ extension AuthenticatedCoordinator {
     }
     
     func onTestbedTapped(_ isRepeat: Bool, coordinator: NavigationViewCoordinator<TestbedEnvironmentObjectCoordinator>) {
-        coordinator.child.popToRoot().popToRoot()
+        if isRepeat {
+            coordinator.child.popToRoot()
+        }
     }
 
     func makeHome() -> HomeCoordinator {

--- a/Examples/App/Shared/Coordinators/Authenticated/AuthenticatedCoordinator+Factory.swift
+++ b/Examples/App/Shared/Coordinators/Authenticated/AuthenticatedCoordinator+Factory.swift
@@ -11,6 +11,10 @@ extension AuthenticatedCoordinator {
         Image(systemName: "bed.double" + (isActive ? ".fill" : ""))
         Text("Testbed")
     }
+    
+    func onTestbedTapped(_ isRepeat: Bool, coordinator: NavigationViewCoordinator<TestbedEnvironmentObjectCoordinator>) {
+        coordinator.child.popToRoot().popToRoot()
+    }
 
     func makeHome() -> HomeCoordinator {
         return HomeCoordinator(todosStore: todosStore)

--- a/Examples/App/Shared/Coordinators/Authenticated/AuthenticatedCoordinator.swift
+++ b/Examples/App/Shared/Coordinators/Authenticated/AuthenticatedCoordinator.swift
@@ -18,7 +18,7 @@ final class AuthenticatedCoordinator: TabCoordinatable {
     @Route(tabItem: makeHomeTab) var home = makeHome
     @Route(tabItem: makeTodosTab) var todos = makeTodos
     @Route(tabItem: makeProfileTab) var profile = makeProfile
-    @Route(tabItem: makeTestbedTab) var testbed = makeTestbed
+    @Route(tabItem: makeTestbedTab, onTapped: onTestbedTapped) var testbed = makeTestbed
     
     init(user: User) {
         self.todosStore = TodosStore(user: user)

--- a/Sources/Stinsen/NavigationCoordinatable/NavigationCoordinatable.swift
+++ b/Sources/Stinsen/NavigationCoordinatable/NavigationCoordinatable.swift
@@ -331,7 +331,7 @@ public extension NavigationCoordinatable {
         self.popTo(int, nil)
     }
     
-    func popLast(_ action: (() -> ())?) {
+    func popLast(_ action: (() -> ())? = nil) {
         self.popTo(self.stack.value.count - 2, action)
     }
     
@@ -357,7 +357,7 @@ public extension NavigationCoordinatable {
         return AnyView(NavigationCoordinatableView(id: -1, coordinator: self))
     }
 
-    func popToRoot(_ action: (() -> ())? = nil) -> Self {
+    @discardableResult func popToRoot(_ action: (() -> ())? = nil) -> Self {
         self.popTo(-1, action)
         return self
     }

--- a/Sources/Stinsen/TabCoordinatable/TabChild.swift
+++ b/Sources/Stinsen/TabCoordinatable/TabChild.swift
@@ -5,6 +5,7 @@ struct TabChildItem {
     let presentable: ViewPresentable
     let keyPathIsEqual: (Any) -> Bool
     let tabItem: (Bool) -> AnyView
+    let onTapped: (Bool) -> Void
 }
 
 /// Wrapper around childCoordinators
@@ -19,6 +20,12 @@ public class TabChild: ObservableObject {
     
     public var activeTab: Int {
         didSet {
+            if oldValue != activeTab {
+                allItems[activeTab].onTapped(false)
+            } else {
+                allItems[oldValue].onTapped(true)
+            }
+            
             guard oldValue != activeTab else { return }
             let newItem = allItems[activeTab]
             self.activeItem = newItem

--- a/Sources/Stinsen/TabCoordinatable/TabChild.swift
+++ b/Sources/Stinsen/TabCoordinatable/TabChild.swift
@@ -20,12 +20,7 @@ public class TabChild: ObservableObject {
     
     public var activeTab: Int {
         didSet {
-            if oldValue != activeTab {
-                allItems[activeTab].onTapped(false)
-            } else {
-                allItems[oldValue].onTapped(true)
-            }
-            
+            allItems[activeTab].onTapped(oldValue == activeTab)            
             guard oldValue != activeTab else { return }
             let newItem = allItems[activeTab]
             self.activeItem = newItem

--- a/Sources/Stinsen/TabCoordinatable/TabCoordinatable.swift
+++ b/Sources/Stinsen/TabCoordinatable/TabCoordinatable.swift
@@ -77,6 +77,9 @@ public extension TabCoordinatable {
                         },
                         tabItem: { [unowned self] in
                             val.tabItem(active: $0, coordinator: self)
+                        },
+                        onTapped: { isRepeat in
+                            val.onTapped(isRepeat, coordinator: self)
                         }
                     )
                 )

--- a/Sources/Stinsen/TabCoordinatable/TabRoute.swift
+++ b/Sources/Stinsen/TabCoordinatable/TabRoute.swift
@@ -4,29 +4,44 @@ import SwiftUI
 protocol Outputable {
     func using(coordinator: Any) -> ViewPresentable
     func tabItem(active: Bool, coordinator: Any) -> AnyView
+    func onTapped(_ isRepeat: Bool, coordinator: Any)
 }
 
-public struct Content<T: TabCoordinatable, Output: ViewPresentable>: Outputable {
+public class Content<T: TabCoordinatable, Output: ViewPresentable>: Outputable {
+    
     func tabItem(active: Bool, coordinator: Any) -> AnyView {
         return self.tabItem(coordinator as! T)(active)
     }
     
     func using(coordinator: Any) -> ViewPresentable {
-        return self.closure(coordinator as! T)()
+        let closureOutput = self.closure(coordinator as! T)()
+        self._output = closureOutput
+        return closureOutput
+    }
+    
+    func onTapped(_ isRepeat: Bool, coordinator: Any) {
+        self.onTapped(coordinator as! T)(isRepeat, _output!)
     }
     
     let closure: ((T) -> (() -> Output))
     let tabItem: ((T) -> ((Bool) -> AnyView))
+    let onTapped: ((T) -> ((Bool, Output) -> Void))
+    
+    private var _output: Output?
     
     init<TabItem: View>(
         closure: @escaping ((T) -> (() -> Output)),
-        tabItem: @escaping ((T) -> ((Bool) -> TabItem))
+        tabItem: @escaping ((T) -> ((Bool) -> TabItem)),
+        onTapped: @escaping ((T) -> ((Bool, Output) -> Void))
     ) {
         self.closure = closure
         self.tabItem = { coordinator in
             return {
                 AnyView(tabItem(coordinator)($0))
             }
+        }
+        self.onTapped = { coordinator in
+            onTapped(coordinator)
         }
     }
 }
@@ -47,9 +62,21 @@ extension TabRoute where T: TabCoordinatable, Output == AnyView {
         self.init(
             standard: Content(
                 closure: { coordinator in { AnyView(wrappedValue(coordinator)()) }},
-                tabItem: tabItem
+                tabItem: tabItem,
+                onTapped: { _ in { _, _ in }}
             )
         )
+    }
+    
+    public convenience init<ViewOutput: View, TabItem: View>(
+        wrappedValue: @escaping ((T) -> (() -> ViewOutput)),
+        tabItem: @escaping ((T) -> ((Bool) -> TabItem)),
+        onTapped: @escaping ((T) -> ((Bool, Output) -> Void))
+    ) {
+        self.init(standard: Content(
+            closure: { coordinator in { AnyView(wrappedValue(coordinator)()) }},
+            tabItem: tabItem,
+            onTapped: onTapped))
     }
 }
 
@@ -61,8 +88,20 @@ extension TabRoute where T: TabCoordinatable, Output: Coordinatable {
         self.init(
             standard: Content(
                 closure: { coordinator in { wrappedValue(coordinator)() }},
-                tabItem: tabItem
+                tabItem: tabItem,
+                onTapped: { _ in { _, _ in }}
             )
         )
+    }
+    
+    public convenience init<TabItem: View>(
+        wrappedValue: @escaping ((T) -> (() -> Output)),
+        tabItem: @escaping ((T) -> ((Bool) -> TabItem)),
+        onTapped: @escaping ((T) -> ((Bool, Output) -> Void))
+    ) {
+        self.init(standard: Content(
+            closure: { coordinator in { wrappedValue(coordinator)() }},
+            tabItem: tabItem,
+            onTapped: onTapped))
     }
 }

--- a/Sources/Stinsen/TabCoordinatable/TabRoute.swift
+++ b/Sources/Stinsen/TabCoordinatable/TabRoute.swift
@@ -15,19 +15,19 @@ public class Content<T: TabCoordinatable, Output: ViewPresentable>: Outputable {
     
     func using(coordinator: Any) -> ViewPresentable {
         let closureOutput = self.closure(coordinator as! T)()
-        self._output = closureOutput
+        self.output = closureOutput
         return closureOutput
     }
     
     func onTapped(_ isRepeat: Bool, coordinator: Any) {
-        self.onTapped(coordinator as! T)(isRepeat, _output!)
+        self.onTapped(coordinator as! T)(isRepeat, output!)
     }
     
     let closure: ((T) -> (() -> Output))
     let tabItem: ((T) -> ((Bool) -> AnyView))
     let onTapped: ((T) -> ((Bool, Output) -> Void))
     
-    private var _output: Output?
+    private var output: Output?
     
     init<TabItem: View>(
         closure: @escaping ((T) -> (() -> Output)),


### PR DESCRIPTION
Adds an `onTapped` method for `TabChildItem`s that can be passed through the property wrapper and indicate whether the tab was just tapped through the `isRepeat` parameter: `false` if the tab was just selected and `true` if it was previously selected and was selected again. The coordinator used along with the tab item is passed to the function for whatever behavior, like popping to the root of a navigation view which I provided in the sample app. 

A probable solution to https://github.com/rundfunk47/stinsen/issues/56 is to have an internal notification fire when the tab is repeated and the corresponding view listens to that notification as I don't think that a `ScrollView/List` or any other information can be grabbed just by being passed a `Coordinator` or `View`. I would have to look more into that.

There is a small undesirable behavior where at least a few (3-4) views/coordinators are pushed, and then `popToRoot()` is called, instead of a single push occurring a few of the views/coordinators pop one at a time. I don't know if this was previous behavior with `popToRoot()` but was just an observation of mine.

I'm only iffy in the `using` function on `Content` by implicitly setting `_output` and force unwrapping it in `onTapped`. I just quickly took this shortcut as `using` is implicitly called when a `TabChildItem` is created but I would want to move setting `_output` to `init`. Let me know if this is requested and I'll readily make the change.