### PR TITLE
Fix: RouterObject retrieve is nil even in the case when there is a not nil router available in the store

### DIFF
--- a/Sources/Stinsen/RouterStore/RouterStore.swift
+++ b/Sources/Stinsen/RouterStore/RouterStore.swift
@@ -31,17 +31,24 @@ public class RouterStore {
 
 public extension RouterStore {
     func store<T: Routable>(router: T) {
+        cleanupRouterStore()
         let ref = WeakRef<AnyObject>(value: router)
         self.routers.insert(ref, at: 0)
     }
     
     func retrieve<T: Routable>() -> T? {
         for router in self.routers {
-            if let router = router.value as? T {
-                return router
+            if let foundRouter = router.value as? T, router.value != nil {
+                return foundRouter
             }
         }
         
         return nil
+    }
+    
+    /// Removes all nil weak references
+    private func cleanupRouterStore() {
+        let notNilRouters = self.routers.filter({ $0.value != nil })
+        self.routers = notNilRouters
     }
 }


### PR DESCRIPTION
RouterStore stores all routers in the wrapper `WeakRef<AnyObject>`. Since AnyObject is not released, the array of the store gets bigger and bigger and holds more and more nil references (screenshot from example app):

![Screenshot 2022-07-17 at 10 42 28](https://user-images.githubusercontent.com/17550858/179390845-8a6a7392-e1b1-471a-8b01-001d53728ed8.png)

As a consequence, also the retrieve function returns routers that are nil even in the case when there is a not nil router (of the same type) available in the store. 

This pull requests cleans up all nil routers when a new router is stored and retrieves not nil routers when there are retrieved.