### PR TITLE
Fix: bring podspec supported versions inline with spm supported versions

### DIFF
--- a/Stinsen.podspec
+++ b/Stinsen.podspec
@@ -9,5 +9,8 @@ Pod::Spec.new do |s|
     s.source_files = 'Sources/Stinsen/**/*.swift'
     s.framework    = 'SwiftUI'
     s.ios.deployment_target  = '13.0'
+    s.osx.deployment_target = '10.15'
+    s.watchos.deployment_target = '7.0'
+    s.tvos.deployment_target = '13.0'
     s.swift_version = '5.3'
 end


### PR DESCRIPTION
Stinsen already has full support for all major Apple platforms (iOS, tvOS, macOS, watchOS), and all are available via SPM, but not through Cocoapods. I figure this is simply because Cocoapods usage is limited these days, along with tvOS, so this need simply hasn't come up yet. (believe me, I'm surprised I'm in this situation as well!)

This PR makes the same platform availability available on SPM now available on Cocoapods as well. 

If this is an oversight on my part and there are reasons to keep these other platforms off of Cocoapods, please let me know!

Thank you for this project.