### PR TITLE
Safely dismissChild coordinator with an `assertionFailure`

### DIFF
--- a/Sources/NavigationCoordinatable/NavigationCoordinatable.swift
+++ b/Sources/NavigationCoordinatable/NavigationCoordinatable.swift
@@ -299,13 +299,16 @@ public extension NavigationCoordinatable {
     }
     
     func dismissChild<T: Coordinatable>(coordinator: T, action: (() -> Void)? = nil) {
-        let value = stack.value.firstIndex { item in
+        guard let value = stack.value.firstIndex(where: { item in
             guard let presentable = item.presentable as? StringIdentifiable else {
                 return false
             }
             
             return presentable.id == coordinator.id
-        }!
+        }) else {
+            assertionFailure("Can not dismiss child when coordinator is top of the stack.")
+            return
+        }
         
         self.popTo(value - 1, action)
     }


### PR DESCRIPTION
Safely dismissChild coordinator with an `assertionFailure` for scenarios where `dismissChild` may be accidentally invoked in succession. A similar patch to https://github.com/rundfunk47/stinsen/pull/59