### PR TITLE
Update onDismiss to support multistack dismissal

### DIFF
--- a/Sources/NavigationCoordinatable/NavigationCoordinatable.swift
+++ b/Sources/NavigationCoordinatable/NavigationCoordinatable.swift
@@ -370,7 +370,7 @@ public extension NavigationCoordinatable {
         _ input: Input,
         onDismiss: @escaping () -> ()
     ) -> Output {
-        stack.dismissalAction[-1] = onDismiss
+        stack.dismissalAction[stack.value.count - 1] = onDismiss
         return self.route(to: route, input)
     }
     
@@ -396,7 +396,7 @@ public extension NavigationCoordinatable {
         to route: KeyPath<Self, Transition<Self, Presentation, Void, Output>>,
         onDismiss: @escaping () -> ()
     ) -> Output {
-        stack.dismissalAction[-1] = onDismiss
+        stack.dismissalAction[stack.value.count - 1] = onDismiss
         return self.route(to: route)
     }
     
@@ -422,7 +422,7 @@ public extension NavigationCoordinatable {
         _ input: Input,
         onDismiss: @escaping () -> ()
     ) -> Self {
-        stack.dismissalAction[-1] = onDismiss
+        stack.dismissalAction[stack.value.count - 1] = onDismiss
         return self.route(to: route, input)
     }
     
@@ -447,7 +447,7 @@ public extension NavigationCoordinatable {
         to route: KeyPath<Self, Transition<Self, Presentation, Void, Output>>,
         onDismiss: @escaping () -> ()
     ) -> Self {
-        stack.dismissalAction[-1] = onDismiss
+        stack.dismissalAction[stack.value.count - 1] = onDismiss
         return self.route(to: route)
     }
     


### PR DESCRIPTION
Originally, onDismiss API didn't take into account if there is more than 1 item in the stack.

Use stack count to store onDismiss action against the correct key.

When user pops/swipes to dismiss the correct `dismissalAction` will be called.