### PR TITLE
Update ViewWrapperCoordinator to allow viewfactory to access coordinator

### DIFF
--- a/Sources/Stinsen/NavigationViewCoordinator/NavigationViewCoordinator.swift
+++ b/Sources/Stinsen/NavigationViewCoordinator/NavigationViewCoordinator.swift
@@ -26,4 +26,9 @@ public class NavigationViewCoordinator<T: Coordinatable>: ViewWrapperCoordinator
     public override init(_ childCoordinator: T, _ view: @escaping (AnyView) -> AnyView) {
         fatalError("view cannot be customized")
     }
+    
+    @available(*, unavailable)
+    public override init(_ childCoordinator: T, _ view: @escaping (any Coordinatable) -> (AnyView) -> AnyView) {
+        fatalError("view cannot be customized")
+    }
 }

--- a/Sources/Stinsen/ViewWrapperCoordinator/ViewWrapperCoordinator.swift
+++ b/Sources/Stinsen/ViewWrapperCoordinator/ViewWrapperCoordinator.swift
@@ -14,15 +14,21 @@ open class ViewWrapperCoordinator<T: Coordinatable, V: View>: Coordinatable {
 
     public weak var parent: ChildDismissable?
     public let child: T
-    private let viewFactory: (AnyView) -> V
+    private let viewFactory: (any Coordinatable) -> (AnyView) -> V
 
     public func view() -> AnyView {
         AnyView(
-            ViewWrapperCoordinatorView(coordinator: self, viewFactory)
+            ViewWrapperCoordinatorView(coordinator: self, viewFactory(self))
         )
     }
     
     public init(_ childCoordinator: T, _ view: @escaping (AnyView) -> V) {
+        self.child = childCoordinator
+        self.viewFactory = { _ in { view($0) } }
+        self.child.parent = self
+    }
+    
+    public init(_ childCoordinator: T, _ view: @escaping (any Coordinatable) -> (AnyView) -> V) {
         self.child = childCoordinator
         self.viewFactory = view
         self.child.parent = self


### PR DESCRIPTION
Allows for the ability to access the coordinator i.e self within the view factory

Example of use:

```swift
final class NavigationCoordinatorWithClose<T: Coordinatable>: ViewWrapperCoordinator<T, AnyView> {
    
    init(_ embedded: T) {
        super.init(embedded) { coordinator in { view in
            AnyView(
                NavigationView {
                    view
                        .toolbar {
                            ToolbarItem(placement: .navigationBarLeading) {
                                Button("Close") {
                                    coordinator.parent?.dismissChild(coordinator: coordinator, action: nil)
                                }
                            }
                       }
                 }
            )
        }}
    }
}
```