### PR TITLE
Fix: Prevent a crash when stack try to dismiss a coordinator without a parent coordinator

### DIFF
--- a/Sources/Stinsen/NavigationCoordinatable/NavigationCoordinatable.swift
+++ b/Sources/Stinsen/NavigationCoordinatable/NavigationCoordinatable.swift
@@ -314,7 +314,11 @@ public extension NavigationCoordinatable {
     }
     
     func dismissCoordinator(_ action: (() -> ())? = nil) {
-        stack.parent!.dismissChild(coordinator: self, action: action)
+        guard let parent = stack.parent else {
+            assertionFailure("Can not dismiss coordinator when parent is null.")
+            return
+        }
+        parent.dismissChild(coordinator: self, action: action)
     }
     
     internal func setupRoot() {

--- a/Sources/Stinsen/NavigationCoordinatable/NavigationStack.swift
+++ b/Sources/Stinsen/NavigationCoordinatable/NavigationStack.swift
@@ -56,6 +56,14 @@ public extension NavigationStack {
     func isInStack(_ keyPathHash: Int) -> Bool {
         return value.contains { $0.keyPath == keyPathHash }
     }
+
+    /**
+    Checks if a parent coordinator
+     - Returns: Boolean indiacting whether the coordinator has a parent
+     */
+    func hasParent() -> Bool {
+        return self.parent != nil
+    }
 }
 
 struct NavigationStackItem {


### PR DESCRIPTION
## 🐛 Fix 
- Prevent a crash when stack try to dismiss a coordinator without a parent coordinator

## 🚀 Feat
- Added hasParent method into NavigationStack to check if coordinator has a parent


### Example of use

```swift
/// Check if the stack has a parent coordinator
if  self.stack.hasParent() {
    self.dismissCoordinator()
}
```