### PR TITLE
Set activeItem on first time opening tabBar

### DIFF
--- a/Sources/Stinsen/TabCoordinatable/TabChild.swift
+++ b/Sources/Stinsen/TabCoordinatable/TabChild.swift
@@ -16,7 +16,12 @@ public class TabChild: ObservableObject {
     
     @Published var activeItem: TabChildItem!
     
-    var allItems: [TabChildItem]!
+    var allItems: [TabChildItem]! {
+        didSet {
+            let newItem = allItems?[safe: activeTab]
+            activeItem = newItem
+        }
+    }
     
     public var activeTab: Int {
         didSet {


### PR DESCRIPTION
The value of activeItem is missing because it is not set after setting allItems.