### PR TITLE
Make NavigationRoute initialiser public

### DIFF
--- a/Sources/Stinsen/NavigationCoordinatable/NavigationRoute.swift
+++ b/Sources/Stinsen/NavigationCoordinatable/NavigationRoute.swift
@@ -17,6 +17,29 @@ public struct Presentation: RouteType {
     let type: PresentationType
 }
 
+public extension RouteType where Self == RootSwitch {
+    static var root: RootSwitch { .init() }
+}
+
+public extension RouteType where Self == Presentation {
+
+    static var modal: Presentation {
+        .init(type: .modal)
+    }
+    
+    static var fullScreen: Presentation {
+        if #available(iOS 14, *) {
+            .init(type: .fullScreen)
+        } else {
+            .init(type: .modal)
+        }
+    }
+    
+    static var push: Presentation {
+        .init(type: .push)
+    }
+}
+
 public struct Transition<T: NavigationCoordinatable, U: RouteType, Input, Output: ViewPresentable>: NavigationOutputable {
     let type: U
     let closure: ((T) -> ((Input) -> Output))
@@ -34,7 +57,7 @@ public struct Transition<T: NavigationCoordinatable, U: RouteType, Input, Output
     
     public var wrappedValue: Transition<T, U, Input, Output>
     
-    init(standard: Transition<T, U, Input, Output>) {
+    public init(standard: Transition<T, U, Input, Output>) {
         self.wrappedValue = standard
     }
 }


### PR DESCRIPTION
Currently, `NavigationRoute` can only be initialised using a property wrapper. However, protocols in Swift do not yet support property wrappers as properties.

There are cases where we'd like to define possible navigation routes in a protocol and allow the protocol’s conforming types to implement them. This PR makes the NavigationRoute initialiser public, allowing routes to be defined in protocols and instantiated without the need for a property wrapper in the implementation.

```
public protocol ScreenBProtocol: NavigationCoordinatable {}

public protocol ScreenAProtocol: NavigationCoordinatable {
    
    associatedtype ScreenB: ScreenBProtocol

    var screenB: NavigationRoute<Self, Presentation, (), ScreenB> { get }
}

public final class ScreenACoordinator<
    ScreenB: ScreenBProtocol,
>: ScreenAProtocol {
    
    public typealias I = ScreenACoordinator<ScreenB>

    public let stack: Stinsen.NavigationStack<I>

    @Root var root = makeRoot
    public var screenB = NavigationRoute(wrappedValue: I.makeScreenB, .modal)

    ...
}
```