### PR TITLE
Add support for disabling interactive dismiss on modal presentations

### DIFF
--- a/Sources/Stinsen/NavigationCoordinatable/NavigationCoordinatableView.swift
+++ b/Sources/Stinsen/NavigationCoordinatable/NavigationCoordinatableView.swift
@@ -2,6 +2,18 @@ import Foundation
 import SwiftUI
 import Combine
 
+extension View {
+    /// Applies `.interactiveDismissDisabled()` on iOS 15+. No-op on earlier versions.
+    @ViewBuilder
+    func interactiveDismissDisabledIfAvailable(_ isDisabled: Bool) -> some View {
+        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+            self.interactiveDismissDisabled(isDisabled)
+        } else {
+            self
+        }
+    }
+}
+
 struct NavigationCoordinatableView<T: NavigationCoordinatable>: View {
     var coordinator: T
     private let id: Int
@@ -85,7 +97,11 @@ struct NavigationCoordinatableView<T: NavigationCoordinatable>: View {
             }, content: { () -> AnyView in
                 return { () -> AnyView in
                     if let view = presentationHelper.presented?.view {
-                        return AnyView(view)
+                        return AnyView(
+                            view.interactiveDismissDisabledIfAvailable(
+                                !(presentationHelper.presented?.type.isModalDismissible ?? true)
+                            )
+                        )
                     } else {
                         return AnyView(EmptyView())
                     }

--- a/Sources/Stinsen/NavigationCoordinatable/PresentationHelper.swift
+++ b/Sources/Stinsen/NavigationCoordinatable/PresentationHelper.swift
@@ -19,8 +19,9 @@ final class PresentationHelper<T: NavigationCoordinatable>: ObservableObject {
         if value.count - 1 == nextId, self.presented == nil {
             if let value = value[safe: nextId] {
                 let presentable = value.presentable
-                switch value.presentationType {
-                case .modal:
+                let presentationType = value.presentationType
+                switch presentationType {
+                case .modal, .modalNonDismissible:
                     if presentable is AnyView {
                         let view = AnyView(NavigationCoordinatableView(id: nextId, coordinator: coordinator))
 
@@ -33,7 +34,7 @@ final class PresentationHelper<T: NavigationCoordinatable>: ObservableObject {
                                     }
                                 )
                             ),
-                            type: .modal
+                            type: presentationType
                         )
                         #else
                         self.presented = Presented(
@@ -45,13 +46,13 @@ final class PresentationHelper<T: NavigationCoordinatable>: ObservableObject {
                                 )
                                 .navigationViewStyle(StackNavigationViewStyle())
                             ),
-                            type: .modal
+                            type: presentationType
                         )
                         #endif
                     } else {
                         self.presented = Presented(
                             view: presentable.view(),
-                            type: .modal
+                            type: presentationType
                         )
                     }
                 case .push:

--- a/Sources/Stinsen/NavigationCoordinatable/PresentationType.swift
+++ b/Sources/Stinsen/NavigationCoordinatable/PresentationType.swift
@@ -3,19 +3,38 @@ import SwiftUI
 
 public enum PresentationType {
     case modal
+    case modalNonDismissible
     case push
     @available(iOS 14, tvOS 14, watchOS 7, *)
     case fullScreen
     
+    /// Creates a modal presentation type with configurable dismiss behavior.
+    /// - Parameter dismissible: Whether the modal can be dismissed by drag gesture. Defaults to `true`.
+    /// - Returns: `.modal` if dismissible, `.modalNonDismissible` if not.
+    public static func modal(dismissible: Bool) -> PresentationType {
+        dismissible ? .modal : .modalNonDismissible
+    }
+
     var isModal: Bool {
         switch self {
-        case .modal:
+        case .modal, .modalNonDismissible:
             return true
         default:
             return false
         }
     }
     
+    var isModalDismissible: Bool {
+        switch self {
+        case .modal:
+            return true
+        case .modalNonDismissible:
+            return false
+        default:
+            return true
+        }
+    }
+
     var isPush: Bool {
         switch self {
         case .push:


### PR DESCRIPTION
## Problem

When using `.modal` presentation, SwiftUI's `.sheet()` allows users to dismiss
by dragging down. There is currently no way to disable this through Stinsen's
route declaration API. Applying `.interactiveDismissDisabled()` on views returned
from route factories has no effect because Stinsen wraps content in
`AnyView(NavigationView { ... })` before passing it to `.sheet()`, which strips
SwiftUI preferences.

## Solution

Added a `modalNonDismissible` case to `PresentationType` with a convenience
static method `.modal(dismissible:)`, allowing routes to opt in to disabling
interactive dismiss:

```swift
// Existing usage — unchanged, drag-dismiss allowed (default)
@Route(.modal)
var editName = makeEditName

// New usage — drag-dismiss disabled
@Route(.modal(dismissible: false))
var editName = makeEditName
```

## Changes

• PresentationType.swift: Added modal​Non​Dismissible case and
static func modal(dismissible: ​Bool) factory method
• PresentationHelper.swift: Handle .modal​Non​Dismissible alongside .modal
• NavigationCoordinatableView.swift: Apply .interactive​Dismiss​Disabled()
inside the sheet content closure, with iOS 15+ availability check

## Backward compatibility

• .modal continues to work exactly as before (drag-dismissible)
• No changes required for existing code
• iOS 13 deployment target preserved via @available check